### PR TITLE
Skip unknowns instead of bailing out

### DIFF
--- a/pkgs/c-abi-lens/src/main.rs
+++ b/pkgs/c-abi-lens/src/main.rs
@@ -188,9 +188,13 @@ fn main() -> Result<()> {
                 .ok_or_eyre("unknown name")
                 .section(error_note.clone())?;
 
-            let field_offset_bits = struct_ty
-                .get_offsetof(&field_name)
-                .map_err(|e| eyre!("unknown offset").error(e).section(error_note.clone()))?;
+            let field_offset_bits = match struct_ty.get_offsetof(&field_name) {
+                Ok(offset) => offset,
+                Err(_) => {
+                    // Skip this field if offset is unknown
+                    continue;
+                }
+            };
 
             let field_ty = struct_field
                 .get_type()


### PR DESCRIPTION
In case `c-abi-lens` is employed, it might fail when the offset is unknown.
This can easily happen, when e.g. the wasi-sysroot is employed as well.

An example by using https://github.com/airbus/a653lib:
`./target/debug/c-abi-lens ../../../a653lib/a653_inc/a653Lib.h -- --target=wasm32-wasi --sysroot=/usr/share/wasi-sysroot`
bails out with:
```
Error: 
   0: unknown offset

Location:
   src/main.rs:187

Error:
   0: the record type has an invalid parent declaration
```
Debugging showed me, that the following struct leads to the issue:
```
struct iovec (size: 1 bytes)
  field: iov_base (offset: 18446744073709551615 bits)
  field: iov_len (offset: 18446744073709551615 bits)
```