### PR TITLE
Repair broken function names.

### DIFF
--- a/pkgs/c-abi-lens/src/main.rs
+++ b/pkgs/c-abi-lens/src/main.rs
@@ -261,7 +261,7 @@ fn generate_getter_setter(
     let prefix = "inline";
     let namespace_prefix = "camw";
     let function_name_gen =
-        |op| format!("{namespace_prefix}_{op}__{struct_name}__{field_name} struct");
+        |op| format!("{namespace_prefix}_{op}__{struct_name}__{field_name}");
     let u8 = "uint8_t";
 
     let type_formatter: Box<dyn FormatToCType>;


### PR DESCRIPTION
the new logic introduces a '<functionname> struct(...)', thus any function is broken.