### PR TITLE
Summary of multiple fixes/feature requests.

### DIFF
--- a/pkgs/c-abi-lens/src/code_gen/tokens.rs
+++ b/pkgs/c-abi-lens/src/code_gen/tokens.rs
@@ -77,7 +77,7 @@ impl CFunc {
             Default::default()
         };
 
-        let prefix = Self::format_func_prefix(func_decl_prefix);
+        let func_decl_prefix = Self::format_func_prefix(func_decl_prefix);
 
         let args = self.format_args();
 
@@ -87,7 +87,7 @@ impl CFunc {
             ";\n".to_owned()
         };
 
-        format!("{comment}{prefix}{return_type} {name}({args}){body}")
+        format!("{comment}{func_decl_prefix}{return_type} {name}({args}){body}")
     }
 
     /// Format a function prefix followed by a space, or an empty string

--- a/pkgs/c-abi-lens/src/main.rs
+++ b/pkgs/c-abi-lens/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
 
     // Print information about the structs
     for struct_ in structs {
-        if let Err(e) = insert_struct_functions(&mut code_snippets, &struct_, endianness_swap) {
+        if let Err(e) = insert_struct_functions(&mut code_snippets, &struct_, endianness_swap, &prefix) {
             error!(
                 "skipping to the next struct, because the following error occured while generating struct functions:\n{e}"
             )


### PR DESCRIPTION
This branch is used in https://github.com/airbus/a653lib/pull/11

1. **BUGFIX**: Create function names `{namespace_prefix}_{op}__{struct_name}__{field_name} struct` without the empty space and struct, which can't be used as a function.
2. **BUGFIX**: For `set`-functions, perform a `*(<type>*)(struct_base_addr + offset) = value` instead of `*(struct_base_addr + offset) = value`. Because the `struct_base_addr` is of type `uint8_t*`, thus current setters are solely writing 1 Byte.
3. **PARTIAL BUGFIX**: Do not bail out if `offset unknown`. `--target=wasm32-wasi --sysroot=...` pulls in `time.h`, with a struct containing a broken offset:
```
struct iovec (size: 1 bytes)
  field: iov_base (offset: 18446744073709551615 bits)
  field: iov_len (offset: 18446744073709551615 bits)
```
4. **FEATURE**: Use `static inline` instead of solely `inline`.
5. **FEATURE**: For struct in struct, provide the address to the nested struct (Example struct: `PROCESS_STATUS_TYPE` which contains `PROCESS_ATTRIBUTE_TYPE ATTRIBUTES` as yet another struct). The nested struct can subsequently employed with anyway given get and set.
6. **FEATURE**: I noticed, that `SAMPLING_PORT_ID_TYPE SAMPLING_PORT_ID` is defined as a `long` thus in theory 4 Byte. While the guest i.e. Wasm32 compiles it to 4 Bytes, the host i.e. x86_64 compiles it to 8 Bytes. As a consequence, when calling `extern void GET_SAMPLING_PORT_STATUS ( /*in */ SAMPLING_PORT_ID_TYPE SAMPLING_PORT_ID, /*out*/ SAMPLING_PORT_STATUS_TYPE *SAMPLING_PORT_STATUS, /*out*/ RETURN_CODE_TYPE *RETURN_CODE )` in Wasm32, passes an address to a 4 Byte memory location (`SAMPLING_PORT_STATUS_TYPE`). However, when naively passing this address to the hosts a653lib, it will write a 8 Byte value to this memory location. Thus overwriting content. Furthermore, a naiiv passthrough does not handle Little-Endian to Big-Endian handling. Thus, all typedefs passed through the ARINC653 function calls must be handled by get/set as well.

**Note**: Todays clang does not have a proper `stdint.h` implementation, in case source code is compiled with `--target=wasm32-wasi` and without `--sysroot=...`. Consequently, most `<u>int<8/16/32/64_t` fields fallback to `int32_t` in Wasm32. In case `--sysroot=...` is employed, this behaviour can't be seen i.e. `stdint.h` types have the expected bitwidth. However, `char`, `short`, `long`, ... have always intended bitwidth in case source code is compiled into Wasm32 (again `--target=wasm32-wasi`). Which means: as long as ARINC653 headers rely on `char`, `short`, `long`, ... one can use `inline` in a Wasm-Runtime offering ARINC653.

**Idea**: We could use the https://man7.org/linux/man-pages/man3/endian.3.html instead of `#include<byteswap.h>`, which simplifies the code significantly as it swaps or not swaps automatically (during compilation it chooses the option). Especially, as the a653lib needs to use such mechanism as well.