### PR TITLE
fix: function namespace prefix from CLI ignored

### DIFF
--- a/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
+++ b/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
@@ -92,8 +92,7 @@ fn emit_per_struct_functions(
     struct_name: &str,
     struct_type: clang::Type,
 ) -> Result<()> {
-    let namespace_prefix = "cal";
-    let function_name_gen = |op| format!("{namespace_prefix}_{op}__{struct_name}");
+    let function_name_gen = |op| format!("{op}__{struct_name}");
 
     let struct_size_bytes = struct_type.get_sizeof()?;
 
@@ -145,8 +144,7 @@ fn emit_per_field_functions(
 
     let offset_bytes = offset_bits / 8;
 
-    let namespace_prefix = "cal";
-    let function_name_gen = |op| format!("{namespace_prefix}_{op}__{struct_name}__{field_name}");
+    let function_name_gen = |op| format!("{op}__{struct_name}__{field_name}");
 
     // desugar this type so that we know what it actually is
     let canonical_type = ty.get_canonical_type();

--- a/pkgs/c-abi-lens/src/main.rs
+++ b/pkgs/c-abi-lens/src/main.rs
@@ -122,6 +122,16 @@ fn main() -> Result<()> {
 
     code_snippets.push(CSnippet::Newline);
 
+    // apply prefix to all function names, if its not an empty string
+    if !prefix.is_empty() {
+        debug!("applying function prefixes");
+        for snippet in &mut code_snippets {
+            if let CSnippet::Func(code_gen::CFunc { name, .. }) = snippet {
+                *name = format!("{prefix}_{name}")
+            }
+        }
+    }
+
     debug!("done generating code, writing output");
 
     // assmeble the code


### PR DESCRIPTION
We did not actually take the function namespace prefix configured via the CLI, but some hardcoded value each time. Now properly fixed.