### PR TITLE
feat: add choice of conditional header fn attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   **Reason**: In order for the `CREATE_PROCESS` call to succeed, the host environment needs to be able to call a guest environment function identified via an index into said table. Exporting the table ensures that the funcref table is accessible from the host environment.
 - **Choice**: Do not use `__externref_t` for function pointers, e.g. the `ENTRY_POINT` argument in the `CREATE_ERROR_HANDLER` function.
   **Reason**: `__externref_t` is not representable in Linear Memory. Hence, it can not become the field of a struct. However, the `PROCESS_ATTRIBUTE_TYPE` struct comprises an `ENTRY_POINT` field holding a function pointer. As `__externref_t` can not be used there, it is necessary to expose the table for function pointers. Therefore, any use of `__externref_t` shall be avoided, in order to keep all function pointer representations consistent.
+- **Choice**: Use `__wasm__` preprocessor `#define` to conditionally annotate official APEX header functions with `import_module` & `import_name` attributes.
+  **Reason**: Clang is the sole compiler, that is capable to compile C to Wasm reasonably. Heaving two headers, one without and one with Wasm specific annotations, is unfavorable.
 
 # Legal Matter
 

--- a/scripts/process-arinc-header.awk
+++ b/scripts/process-arinc-header.awk
@@ -8,6 +8,12 @@ BEGIN {
   # ORS = "\n";
 
   BINMODE = 0;
+
+  print("#ifdef  __wasm__")
+  print("#define  WASM_IMPORT_MODULE(module, name)  __attribute__((import_module(module), import_name(name)))")
+  print("#else")
+  print("#define  WASM_IMPORT_MODULE(module, name)")
+  print("#endif")
 }
 
 # detect that we are in an implementation dependent section of the header
@@ -23,7 +29,7 @@ BEGIN {
 # mark all functions to be importend from the arinc module
 "extern" == $1 && "void" == $2 && $4 ~/^\(/ {
   import_module = "arinc653:p1@0.1.0";
-  print "__attribute__((import_module(\"" import_module "\"), import_name(\"" $3 "\")))"
+  print "WASM_IMPORT_MODULE(\"" import_module "\", \"" $3 "\")"
 }
 
 # make all function pointers actually be function pointers


### PR DESCRIPTION
Document why C-preprocessor macros are used to make the ARINC 653 header file Wasm agnostic.