### PR TITLE
Improvement collection to let airbus/a653lib Wamr/Wasmtime support compile

### DIFF
--- a/pkgs/c-abi-lens/src/code_gen/c_types.rs
+++ b/pkgs/c-abi-lens/src/code_gen/c_types.rs
@@ -51,6 +51,16 @@ impl RepresentableCType {
                 })
             }
 
+            // pointers are represented as unsigned integers of the target's pointer width
+            // (e.g. uint32_t on wasm32, uint64_t on x86_64)
+            (Pointer, 1 | 2 | 4 | 8, _) => {
+                let size = size_of.try_into().unwrap();
+                Ok(RepresentableCType::Integer {
+                    bytes: size,
+                    is_unsigned: true, // pointers are always treated as unsigned
+                })
+            }
+
             // its a float of some sorts
             (Float | Double, 4 | 8, _) => {
                 let size = size_of.try_into().unwrap(); // 4 | 8 all fit into an u8

--- a/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
+++ b/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
@@ -178,7 +178,7 @@ fn emit_per_field_functions(
     );
     code_snippets.push(CSnippet::Newline);
 
-    // helper functions for offset of the field withing the struct
+    // helper functions for offset of the field within the struct
     code_snippets.push(CFunc {
         comment: format!("\
             `offsetof({struct_name}, {field_name})`\n\
@@ -192,21 +192,15 @@ fn emit_per_field_functions(
     }.into());
     code_snippets.push(CSnippet::Newline);
 
-    // string to anounce the presence of byte-swapping
+    // string to announce the presence of byte-swapping
     let maybe_endianness_swapped = if swap_endianness {
         ", with endianness swapped"
     } else {
         ""
     };
 
-    // function/macro to perform byte swapping
-    let byte_swap_fn = match generic_c_field_repr.element_size_bytes()? {
-        1 => "".to_owned(),
-        n @ 2 | n @ 4 | n @ 8 => format!("bswap_{}", 8 * n),
-        n => {
-            bail!("unable to perform a byte swap for an integer that is {n} bytes wide")
-        }
-    };
+    // NOTE: byte_swap_fn is now computed inside the arms that need it,
+    // to avoid bailing out early for Record types (nested structs)
 
     use clang::TypeKind::*;
     match (
@@ -214,6 +208,25 @@ fn emit_per_field_functions(
         canonical_type.get_element_type(),
         generic_c_field_repr.element_type(),
     ) {
+        // nested struct: just return base address pointer, no swap needed/possible
+        (Record, _, _) => {
+            code_snippets.insert(code_snippets.len() - 2, CFunc {
+                comment: format!("\
+                    Get struct address `{struct_name}.{field_name}`\n\
+                    \n\
+                    Returns the field `{field_name}`'s struct address from an instance of the `{struct_name}` struct\
+                "),
+                return_type: RepresentableCType::Opaque { bytes: None },
+                name: function_name_gen("get_struct_base_addr"),
+                arguments: [(
+                    RepresentableCType::Opaque { bytes: None },
+                    "struct_base_addr".to_owned(),
+                )].into(),
+                body: format!("return (void *)((uint8_t *)struct_base_addr + {offset_bytes});"),
+            }.into());
+            code_snippets.insert(code_snippets.len() - 2, CSnippet::Newline);
+        }
+
         // integer or float or pointer
         (
             CharS | CharU | SChar | UChar | Short | UShort | Int | UInt | Long | ULong | LongLong
@@ -221,6 +234,12 @@ fn emit_per_field_functions(
             _,
             _,
         ) => {
+            let byte_swap_fn = match generic_c_field_repr.element_size_bytes()? {
+                1 => "".to_owned(),
+                n @ 2 | n @ 4 | n @ 8 => format!("bswap_{}", 8 * n),
+                n => bail!("unable to perform a byte swap for an integer that is {n} bytes wide"),
+            };
+
             // C code string that might swap the bytes of `value` or does nothing
             let maybe_byteswap =
                 if swap_endianness && generic_c_field_repr.element_size_bytes()? != 1 {
@@ -279,6 +298,12 @@ fn emit_per_field_functions(
             Some(_),
             RepresentableCType::Integer { .. } | RepresentableCType::Float { .. },
         ) => {
+            let _byte_swap_fn = match generic_c_field_repr.element_size_bytes()? {
+                1 => "".to_owned(),
+                n @ 2 | n @ 4 | n @ 8 => format!("bswap_{}", 8 * n),
+                n => bail!("unable to perform a byte swap for an integer that is {n} bytes wide"),
+            };
+
             let total_bytes = generic_c_field_repr.total_size_bytes()?;
             let element_bytes = generic_c_field_repr.element_size_bytes()?;
 

--- a/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
+++ b/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
@@ -387,3 +387,175 @@ fn emit_per_field_functions(
 
     Ok(())
 }
+
+/// Emit all functions for a given typedef
+pub fn insert_typedef_functions(
+    code_snippets: &mut Vec<CSnippet>,
+    typedef_: &clang::Entity,
+    swap_endianness: bool,
+) -> Result<()> {
+    let typedef_name = typedef_.get_name().ok_or_eyre("typedef has no name")?;
+    info!("generating for typedef {typedef_name:?}");
+
+    let typedef_ty = typedef_
+        .get_type()
+        .ok_or_eyre("typedef type is unknown?!")?;
+    let canonical_type = typedef_ty.get_canonical_type();
+    let generic_c_repr = RepresentableCType::new(&canonical_type)?;
+
+    let function_name_gen = |op| format!("{op}__{typedef_name}");
+
+    // section header
+    code_snippets.push(
+        CSection {
+            title: format!(" {typedef_name} "),
+            comment: Default::default(),
+        }
+        .into(),
+    );
+    code_snippets.push(CSnippet::Newline);
+
+    // string to announce the presence of byte-swapping
+    let maybe_endianness_swapped = if swap_endianness {
+        ", with endianness swapped"
+    } else {
+        ""
+    };
+
+    use clang::TypeKind::*;
+    match (canonical_type.get_kind(), canonical_type.get_element_type()) {
+        // integer or float or pointer
+        (
+            CharS | CharU | SChar | UChar | Short | UShort | Int | UInt | Long | ULong | LongLong
+            | ULongLong | Float | Double | Pointer | Enum,
+            _,
+        ) => {
+            let byte_swap_fn = match generic_c_repr.element_size_bytes()? {
+                1 => "".to_owned(),
+                n @ 2 | n @ 4 | n @ 8 => format!("bswap_{}", 8 * n),
+                n => bail!("unable to perform a byte swap for an integer that is {n} bytes wide"),
+            };
+
+            let maybe_byteswap = if swap_endianness && generic_c_repr.element_size_bytes()? != 1 {
+                format!("value = {byte_swap_fn}(value);\n")
+            } else {
+                String::default()
+            };
+
+            // getter
+            code_snippets.push(CFunc {
+                comment: format!("\
+                    Get `{typedef_name}`\n\
+                    \n\
+                    Returns the typedef `{typedef_name}`'s value from memory{maybe_endianness_swapped}\
+                "),
+                return_type: generic_c_repr.clone(),
+                name: function_name_gen("get"),
+                arguments: [
+                     (RepresentableCType::Opaque { bytes: None }, "base_addr".to_owned())
+                ].into(),
+                body: format!("\
+                    {};\n\
+                    memcpy(&value, base_addr, sizeof(value));\n\
+                    {maybe_byteswap}return value;\
+                    ", generic_c_repr.format_as_type(Some("value"))
+                ),
+            }.into());
+            code_snippets.push(CSnippet::Newline);
+
+            // setter
+            code_snippets.push(CFunc {
+                comment: format!("\
+                    Set `{typedef_name}` to `value`\n\
+                    \n\
+                    Overwrites the typedef `{typedef_name}`'s value at a memory location{maybe_endianness_swapped}\
+                "),
+                return_type: RepresentableCType::Void,
+                name: function_name_gen("set"),
+                arguments: [
+                     (RepresentableCType::Opaque { bytes: None }, "base_addr".to_owned()), (generic_c_repr.clone(), "value".to_owned())
+                ].into(),
+                body: format!("\
+                     {maybe_byteswap}\
+                     memcpy(base_addr, &value, sizeof(value));\
+                ")
+            }.into());
+            code_snippets.push(CSnippet::Newline);
+        }
+
+        // array of single-byte elements
+        (ConstantArray, Some(element_ty)) if element_ty.get_sizeof() == Ok(1) => {
+            let total_bytes = generic_c_repr.total_size_bytes()?;
+
+            // reader
+            code_snippets.push(
+                CFunc {
+                    comment: format!(
+                        "\
+                    Read from `{typedef_name}`\n\
+                    \n\
+                    Copies from `{typedef_name}` memory location to `dst`{maybe_endianness_swapped}\
+                "
+                    ),
+                    return_type: RepresentableCType::Void,
+                    name: function_name_gen("read"),
+                    arguments: [
+                        (
+                            RepresentableCType::Opaque { bytes: None },
+                            "base_addr".to_owned(),
+                        ),
+                        (generic_c_repr.clone(), "dst".to_owned()),
+                    ]
+                    .into(),
+                    body: format!("memcpy((uint8_t *)dst, (uint8_t *)base_addr, {total_bytes});"),
+                }
+                .into(),
+            );
+            code_snippets.push(CSnippet::Newline);
+
+            // writer
+            code_snippets.push(CFunc {
+                comment: format!("\
+                    Write to `{typedef_name}`\n\
+                    \n\
+                    Copies from `src` to the `{typedef_name}` memory location{maybe_endianness_swapped}\
+                "),
+                return_type: RepresentableCType::Void,
+                name: function_name_gen("write"),
+                arguments: [
+                    (RepresentableCType::Opaque { bytes: None }, "base_addr".to_owned()), (generic_c_repr.clone(), "src".to_owned())
+                ].into(),
+                body: format!("memcpy((uint8_t *)base_addr, (uint8_t *)src, {total_bytes});"),
+            }.into());
+            code_snippets.push(CSnippet::Newline);
+        }
+
+        (type_kind, maybe_type) => {
+            debug!(
+                "don't know how to represent typedef {typedef_name:?} of kind {type_kind:?} (element: {maybe_type:?}), skipping"
+            );
+            return Ok(());
+        }
+    }
+
+    // sizeof
+    code_snippets.push(
+        CFunc {
+            comment: format!(
+                "\
+`sizeof({typedef_name})`\n\
+\n\
+Returns the size in bytes of the typedef `{typedef_name}`\
+"
+            ),
+            return_type: RepresentableCType::UIntPtr,
+            name: function_name_gen("sizeof"),
+            arguments: vec![],
+            body: format!("return {};", generic_c_repr.total_size_bytes()?),
+        }
+        .into(),
+    );
+    code_snippets.push(CSnippet::Newline);
+
+    Ok(())
+}

--- a/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
+++ b/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
@@ -230,7 +230,7 @@ fn emit_per_field_functions(
         // integer or float or pointer
         (
             CharS | CharU | SChar | UChar | Short | UShort | Int | UInt | Long | ULong | LongLong
-            | ULongLong | Float | Double | Enum,
+            | ULongLong | Float | Double | Pointer | Enum,
             _,
             _,
         ) => {

--- a/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
+++ b/pkgs/c-abi-lens/src/code_gen/function_emitter.rs
@@ -308,7 +308,7 @@ fn emit_per_field_functions(
             let element_bytes = generic_c_field_repr.element_size_bytes()?;
 
             // C code string that copies from `src_name` to `dst_name` and might swap endianness of elements while doing so
-            let copy_and_maybe_byteswap = |src_name, dst_name| {
+            let copy_and_maybe_byteswap = |src_name: &str, dst_name: &str| {
                 if swap_endianness && element_bytes != 1 {
                     // endianness swapping on the target type is not possible for the write case,
                     // because the target addresses within `struct_base_addr` might not be aligned
@@ -338,7 +338,8 @@ fn emit_per_field_functions(
                     (RepresentableCType::Opaque { bytes: None }, "struct_base_addr".to_owned()),
                     (generic_c_field_repr.clone(), "dst".to_owned())
                 ].into(),
-                body: copy_and_maybe_byteswap("struct_base_addr", "dst")
+                // source is struct_base_addr + offset_bytes
+                body: copy_and_maybe_byteswap(&format!("((uint8_t *)struct_base_addr + {offset_bytes})"), "dst")
             }.into());
             code_snippets.insert(code_snippets.len() - 2, CSnippet::Newline);
 
@@ -355,7 +356,8 @@ fn emit_per_field_functions(
                     (RepresentableCType::Opaque { bytes: None }, "struct_base_addr".to_owned()),
                     (generic_c_field_repr.clone(), "src".to_owned())
                 ].into(),
-                body: copy_and_maybe_byteswap("src", "struct_base_addr")
+                // destination is struct_base_addr + offset_bytes
+                body: copy_and_maybe_byteswap("src", &format!("((uint8_t *)struct_base_addr + {offset_bytes})"))
             }.into());
             code_snippets.insert(code_snippets.len() - 2, CSnippet::Newline);
         }

--- a/pkgs/c-abi-lens/src/main.rs
+++ b/pkgs/c-abi-lens/src/main.rs
@@ -8,7 +8,7 @@ use clang::*;
 
 use clap::Parser;
 use cli::Cli;
-use code_gen::{CInclude, CSection, CSnippet, insert_struct_functions};
+use code_gen::{CInclude, CSection, CSnippet, insert_struct_functions, insert_typedef_functions};
 use color_eyre::{Result, eyre::eyre};
 use log::{debug, error};
 
@@ -72,6 +72,24 @@ fn main() -> Result<()> {
         .filter(|e| e.get_kind() == EntityKind::StructDecl)
         .collect::<Vec<_>>();
 
+    // Get the typedefs in this translation unit (excluding Record/struct types, those are handled above)
+    let typedefs = tu
+        .get_entity()
+        .get_children()
+        .into_iter()
+        .filter(|e| {
+            if e.get_kind() != EntityKind::TypedefDecl {
+                return false;
+            }
+            if let Some(ty) = e.get_type() {
+                let canonical_kind = ty.get_canonical_type().get_kind();
+                canonical_kind != TypeKind::Record
+            } else {
+                false
+            }
+        })
+        .collect::<Vec<_>>();
+
     let mut code_snippets = Vec::new();
 
     // section header for the entire library
@@ -114,6 +132,15 @@ fn main() -> Result<()> {
 
     code_snippets.push(CSnippet::Newline);
     code_snippets.push(CSnippet::Newline);
+
+    // Print information about the typedefs
+    for typedef_ in typedefs {
+        if let Err(e) = insert_typedef_functions(&mut code_snippets, &typedef_, endianness_swap) {
+            error!(
+                "skipping to the next typedef, because the following error occured while generating typedef functions:\n{e}"
+            )
+        }
+    }
 
     // Print information about the structs
     for struct_ in structs {


### PR DESCRIPTION
1. BUGFIX: Re-add the return of base address pointer of a nested struct

In an older c-abi-lens I am obtaining and using:
```
// Get struct address PROCESS_STATUS_TYPE.ATTRIBUTES
//
// Returns the field ATTRIBUTES's struct address from an instance of the PROCESS_STATUS_TYPE struct
uint8_t* cal_get_struct_base_addr__PROCESS_STATUS_TYPE__ATTRIBUTES(uint8_t * struct_base_addr) {
  return (uint8_t*)(struct_base_addr + 16);
}
```

However, the current version fails due to:
```
[*] generating for struct "BLACKBOARD_STATUS_TYPE"
[*] generating for struct "BUFFER_STATUS_TYPE"
[*] generating for struct "ERROR_STATUS_TYPE"
[*] generating for struct "EVENT_STATUS_TYPE"
[*] generating for struct "PARTITION_STATUS_TYPE"
[*] generating for struct "PROCESS_ATTRIBUTE_TYPE"
[*] generating for struct "PROCESS_STATUS_TYPE"
[E] generating the per-field functions for struct "PROCESS_STATUS_TYPE", field Entity { kind: FieldDecl, display_name: Some("ATTRIBUTES"), location: Some(SourceLocation { file: Some(File { path: "/home/ps/a653lib/build-wasm/a653_inc/a653Process.h" }), line: 71, column: 26, offset: 2403 }) } yielded the following error, skipping it |  unable to perform a byte swap for an integer that is 64 bytes wide
[*] generating for struct "QUEUING_PORT_STATUS_TYPE"
[*] generating for struct "SAMPLING_PORT_STATUS_TYPE"
[*] generating for struct "SAMPLING_PORT_CURRENT_STATUS_TYPE"
[*] generating for struct "SEMAPHORE_STATUS_TYPE"
[*] generating for struct "MUTEX_STATUS_TYPE"
```

The given patch ensures that `byte_swap` is performed not in the case of a nested struct. Tp this, the target for a nested struct is added.

---------------------------------

2. BUGFIX: memcpy offset for arrays is missing the field offset in the new code

// new (doc 16) - BUG: missing offset
memcpy((uint8_t *)dst, (uint8_t *)struct_base_addr, 128);

// old (doc 15) - correct
dst[i] = struct_base_addr[16 + i];

---------------------------------

3. BUGFIX: pointers are represented as unsigned integers of the target's pointer width

The current implementation does not generate `cal_set__PROCESS_ATTRIBUTE_TYPE__ENTRY_POINT()`, as it passes a pointer. However, the old implementation generated:
The most naiiv setter would be:
```
/* Set PROCESS_ATTRIBUTE_TYPE.ENTRY_POINT to value
 *
 * Overwrites the field ENTRY_POINT's value of an PROCESS_ATTRIBUTE_TYPE struct instance with value
 */
void cal_set__PROCESS_ATTRIBUTE_TYPE__ENTRY_POINT(void * struct_base_addr, void * value){
    memcpy(((uint8_t *) struct_base_addr + 16), &value, sizeof(value));
}
```
however, the `void*` is solely 32bit in wasm32, thus the recovered logic produces now:

```
/* Set `PROCESS_ATTRIBUTE_TYPE.ENTRY_POINT` to `value`
 *
 * Overwrites the field `ENTRY_POINT`'s value of an `PROCESS_ATTRIBUTE_TYPE` struct instance with `value`
 */
static inline __attribute__((always_inline)) void cal_set__PROCESS_ATTRIBUTE_TYPE__ENTRY_POINT(void * struct_base_addr, uint32_t value){
    memcpy(((uint8_t *) struct_base_addr + 16), &value, sizeof(value));
}
```

---------------------------------

4. BUGFIX: Re-add the creation of getters/setters for all typedefs

